### PR TITLE
DB::count(): improve compatibility

### DIFF
--- a/src/Core/DB.php
+++ b/src/Core/DB.php
@@ -320,10 +320,9 @@ class DB
     {
         $this->last_stmt = $this->connection->prepare("SELECT COUNT(*) FROM $table WHERE $conds");
         $this->last_stmt->execute($args);
+        $result = $this->last_stmt->fetch(PDO::FETCH_NUM);
 
-        $result = $this->last_stmt->fetchAll();
-
-        return empty($result) ? 0 : $result[0]['COUNT(*)'];
+        return empty($result) ? 0 : $result[0];
     }
 
 


### PR DESCRIPTION
Addresses #10
The DB::count() function assumes that a query including `COUNT(*)` in the `SELECT` will return a column named `COUNT(*)`. This is not true in all database drivers! In Postgres, the column will be named `count`. In MSSQL, the column will be `unknown` (IIRC).
By fetching only 1 row (which is all that the query will return) using mode `PDO::FETCH_NUM`, we can avoid this issue completely.